### PR TITLE
Create public folder in package and dont package other files

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -25,11 +25,14 @@ jobs:
       - name: Run build all
         run: make all
 
+      - name: Copy to public folder
+        run: cp -R ./build/html ./public
+
       - name: Add version file
-        run: 'echo "{ \"version\": \"${{ env.RELEASE_VERSION }}\", \"git_ref\": \"$GITHUB_SHA\"}" > build/version.json'
+        run: 'echo "{ \"version\": \"${{ env.RELEASE_VERSION }}\", \"git_ref\": \"$GITHUB_SHA\"}" > public/version.json'
 
       - name: Create tar
-        run: tar -czf gfmodules-functional-documentation_${{ env.RELEASE_VERSION }}.tar.gz build
+        run: tar -czf gfmodules-functional-documentation_${{ env.RELEASE_VERSION }}.tar.gz public/
 
       - name: Upload release tar
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Commit was reversed in https://github.com/minvws/gfmodules-functional-documentation/commit/36d7d30691e67533efae0ac83eb24a1dec5bc815 without explanation. 

To deploy we need files to be in the public folder (for consistency between this and other projects). We also don't need all the other files.