### PR TITLE
chore: update custom.css with hover style workaround for footer links

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -6,7 +6,7 @@ p:has(img:only-child) {
     align-self: stretch;
 }
 
-body>footer nav a:hover{
+body>footer nav a:hover {
     /* For now just a workaround, will be fixed in the next stable release of Manon */
     color: #ffffff !important;
- }
+}


### PR DESCRIPTION
This PR fixes hovering over a link in the footer issue, see [issue](https://github.com/minvws/gfmodules-functional-documentation/issues/23)

>For now just a workaround, should be fixed in the next stable release of Manon!